### PR TITLE
Feature/Support async-await

### DIFF
--- a/InjectGrail.podspec
+++ b/InjectGrail.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'InjectGrail'
-  s.version          = '0.1.8'
+  s.version          = '0.2.0'
   s.summary          = 'Holy Grail of  Swift Injection frameworks for iOS and MacOs.'
   s.description      = <<-DESC
 Tired of injection framework that puts everything in one big bag of dependecy resolvers? This framework might be good for you.
@@ -25,5 +25,5 @@ Tired of injection framework that puts everything in one big bag of dependecy re
 
   s.source_files = 'InjectGrail/Classes/**/*.{swift}'
   s.preserve_paths          = 'Scripts', 'Templates'
-  s.dependency 'Sourcery', '~> 1.6.1'
+  s.dependency 'Sourcery', '~> 1.8.2'
 end

--- a/InjectGrail/Classes/Protocols.swift
+++ b/InjectGrail/Classes/Protocols.swift
@@ -8,11 +8,14 @@
 import Foundation
 
 // Defines properties that can be injected to certain class
+@MainActor
 public protocol Injector {}
 
 // Defines root properties that can be injected into other classes. There can be only one type conforming to this
+@MainActor
 public protocol RootInjector {}
 
+@MainActor
 public protocol Injectable {
     associatedtype ActualInjector: Injector
 


### PR DESCRIPTION
To fully support async-await, InjectGrail protocols must be annotated with MainActor.

Updated Sourcery to 1.8.2.

InjectGrail version set to 0.2.0