### PR TITLE
[HHC-2947]: Same type property matching

### DIFF
--- a/Templates/Inject.swifttemplate
+++ b/Templates/Inject.swifttemplate
@@ -57,7 +57,7 @@ func sorted(_ properties: [Property]) -> [Property] {
 }
 
 // Try to find source of the property in the list of properties available in parent
-func resolvePropertyFromSource(property: Property, allProperties: [Property], sourceProperties: [Property]) -> Property? {
+func resolvePropertyFromSource(property: Property, sourceProperties: [Property]) -> Property? {
   if (property.forceManual) {
       return nil
     }
@@ -67,34 +67,32 @@ func resolvePropertyFromSource(property: Property, allProperties: [Property], so
   }
 
   let sourcePropertiesOfSameType = sourceProperties.filter({$0.type == property.type})
-  let allPropertiesOfSameType = allProperties.filter({$0.type == property.type})
-  let hasMoreThanOneSameTypeProperty = sourcePropertiesOfSameType.count > 1 || allPropertiesOfSameType.count > 1
-
-  if hasMoreThanOneSameTypeProperty {
-    let sourcePropertiesWithSameName = sourcePropertiesOfSameType.filter({$0.name == property.name})
-    return sourcePropertiesWithSameName.first
-  } else {
-      return sourcePropertiesOfSameType.first
-  }
+  let sourcePropertiesWithSameName = sourcePropertiesOfSameType.filter({$0.name == property.name})
+  return sourcePropertiesWithSameName.first
 }
 
-func resolvePropertyFromInjectingRecursively(resolvedProperty: Property, allProperties: [Property], sourceInjector: String, sourceProperties: [String: [Property]], injectorsToInjectorsThatInject: [String: [String]], rootProperties: [Property]) -> Property? {
-      
+func resolvePropertyFromInjectingRecursively(
+    resolvedProperty: Property,
+    resolvedInjector: String,
+    sourceInjector: String,
+    sourceProperties: [String: [Property]],
+    injectorsToInjectorsThatInject: [String: [String]],
+    rootProperties: [Property]
+) -> Property? {
+
     // Try to get property from direct parent
     let properties = sourceProperties[sourceInjector] ?? []
     if let matched = resolvePropertyFromSource(
         property: resolvedProperty,
-        allProperties: allProperties,
         sourceProperties:properties
     ) {
-      log("RESOLVED FROM PARENT | ")
+      log("RESOLVED FROM PARENT | \(sourceInjector)")
       return matched
     }
 
     // Try to get property from root injector
     if let matched = resolvePropertyFromSource(
         property: resolvedProperty,
-        allProperties: allProperties,
         sourceProperties: rootProperties
     ) {
       log("RESOLVED FROM ROOT | ")
@@ -105,19 +103,19 @@ func resolvePropertyFromInjectingRecursively(resolvedProperty: Property, allProp
     for parent in (injectorsToInjectorsThatInject[sourceInjector] ?? []) {
       if let matched = resolvePropertyFromInjectingRecursively(
             resolvedProperty: resolvedProperty,
-            allProperties: allProperties,
+            resolvedInjector: resolvedInjector,
             sourceInjector: parent,
             sourceProperties: sourceProperties,
             injectorsToInjectorsThatInject: injectorsToInjectorsThatInject,
             rootProperties: rootProperties
       ) {
-        log("RESOLVED FROM GRAND PARENT | ")
+        log("RESOLVED FROM GRAND PARENT | \(parent)")
         return matched
       }
     }
     
     log("NOT FOUND | ")
-    return nil
+    fatalError("Unable to resolve property: \(resolvedProperty) from injector: \(resolvedInjector)")
 }
 
 func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToInjectors: [String: String], injectablesToInjectors: [String: String], injectablesToInjects: [String: [String]]) -> [String: [Property]] {
@@ -179,7 +177,7 @@ func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToI
           log("\(injector):\(property.type) \t\t")
             if let matched = resolvePropertyFromInjectingRecursively(
                 resolvedProperty: property,
-                allProperties: currentInjectorProperties,
+                resolvedInjector: injector,
                 sourceInjector: injectorThatInjects,
                 sourceProperties: injectorProperties,
                 injectorsToInjectorsThatInject: injectorsToInjectorsThatInject,
@@ -187,7 +185,6 @@ func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToI
             ) {
               if resolvePropertyFromSource(
                     property: matched,
-                    allProperties: currentInjectorProperties,
                     sourceProperties: injectorProperties[injectorThatInjects] ?? []
               ) == nil {
                 //Append properties need by curren injector if not present in this injector, but found in parent or in the root
@@ -225,7 +222,6 @@ func outputInjectFunction(injectorType :String, parentType: String, injectorProp
   targetProperties.forEach({targetProperty in 
     if let sourceProperty = resolvePropertyFromSource(
         property: targetProperty,
-        allProperties: targetProperties,
         sourceProperties: sourceProperties
     ) {
       log("\(targetProperty.name) -> \(parentType):\(sourceProperty.name)\n")
@@ -337,4 +333,3 @@ extension <%= type.name %> {
 protocol Injects<%= injector %> {}
 
 <%_ } -%>
-

--- a/Templates/Inject.swifttemplate
+++ b/Templates/Inject.swifttemplate
@@ -18,7 +18,7 @@ import <%= `import` %>
 <%_ 
 
 func log(_ text: String) {
-    // Log.error(text)
+    //Log.error(text)
 }
 
 struct Property {
@@ -57,7 +57,7 @@ func sorted(_ properties: [Property]) -> [Property] {
 }
 
 // Try to find source of the property in the list of properties available in parent
-func resolvePropertyFromSource(property: Property, sourceProperties: [Property]) -> Property? {
+func resolvePropertyFromSource(property: Property, allProperties: [Property], sourceProperties: [Property]) -> Property? {
   if (property.forceManual) {
       return nil
     }
@@ -67,28 +67,50 @@ func resolvePropertyFromSource(property: Property, sourceProperties: [Property])
   }
 
   let sourcePropertiesOfSameType = sourceProperties.filter({$0.type == property.type})
-  let sourcePropertiesWithSameName = sourcePropertiesOfSameType.filter({$0.name == property.name})
-  return sourcePropertiesWithSameName.first
+  let allPropertiesOfSameType = allProperties.filter({$0.type == property.type})
+  let hasMoreThanOneSameTypeProperty = sourcePropertiesOfSameType.count > 1 || allPropertiesOfSameType.count > 1
+
+  if hasMoreThanOneSameTypeProperty {
+    let sourcePropertiesWithSameName = sourcePropertiesOfSameType.filter({$0.name == property.name})
+    return sourcePropertiesWithSameName.first
+  } else {
+      return sourcePropertiesOfSameType.first
+  }
 }
 
-func resolvePropertyFromInjectingRecursively(property: Property, injector: String, sourceProperties: [String: [Property]], injectorsToInjectorsThatInject: [String: [String]], rootProperties: [Property]) -> Property? {
+func resolvePropertyFromInjectingRecursively(resolvedProperty: Property, allProperties: [Property], sourceInjector: String, sourceProperties: [String: [Property]], injectorsToInjectorsThatInject: [String: [String]], rootProperties: [Property]) -> Property? {
       
     // Try to get property from direct parent
-    let properties = sourceProperties[injector] ?? []
-    if let matched = resolvePropertyFromSource(property: property, sourceProperties:properties) {
+    let properties = sourceProperties[sourceInjector] ?? []
+    if let matched = resolvePropertyFromSource(
+        property: resolvedProperty,
+        allProperties: allProperties,
+        sourceProperties:properties
+    ) {
       log("RESOLVED FROM PARENT | ")
       return matched
     }
 
     // Try to get property from root injector
-    if let matched = resolvePropertyFromSource(property: property,  sourceProperties:rootProperties) {
+    if let matched = resolvePropertyFromSource(
+        property: resolvedProperty,
+        allProperties: allProperties,
+        sourceProperties: rootProperties
+    ) {
       log("RESOLVED FROM ROOT | ")
       return matched
     }
 
    // Traverse hierarchy
-    for parent in (injectorsToInjectorsThatInject[injector] ?? []) {
-      if let matched = resolvePropertyFromInjectingRecursively(property: property, injector: parent, sourceProperties: sourceProperties, injectorsToInjectorsThatInject: injectorsToInjectorsThatInject, rootProperties: rootProperties) {
+    for parent in (injectorsToInjectorsThatInject[sourceInjector] ?? []) {
+      if let matched = resolvePropertyFromInjectingRecursively(
+            resolvedProperty: resolvedProperty,
+            allProperties: allProperties,
+            sourceInjector: parent,
+            sourceProperties: sourceProperties,
+            injectorsToInjectorsThatInject: injectorsToInjectorsThatInject,
+            rootProperties: rootProperties
+      ) {
         log("RESOLVED FROM GRAND PARENT | ")
         return matched
       }
@@ -155,8 +177,19 @@ func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToI
         log("Injected by \(injectorThatInjects)\n")
         for property in currentInjectorProperties {
           log("\(injector):\(property.type) \t\t")
-            if let matched = resolvePropertyFromInjectingRecursively(property: property, injector: injectorThatInjects, sourceProperties: injectorProperties, injectorsToInjectorsThatInject: injectorsToInjectorsThatInject, rootProperties: rootInjectorProperties) {
-              if resolvePropertyFromSource(property: matched, sourceProperties: injectorProperties[injectorThatInjects] ?? []) == nil {
+            if let matched = resolvePropertyFromInjectingRecursively(
+                resolvedProperty: property,
+                allProperties: currentInjectorProperties,
+                sourceInjector: injectorThatInjects,
+                sourceProperties: injectorProperties,
+                injectorsToInjectorsThatInject: injectorsToInjectorsThatInject,
+                rootProperties: rootInjectorProperties
+            ) {
+              if resolvePropertyFromSource(
+                    property: matched,
+                    allProperties: currentInjectorProperties,
+                    sourceProperties: injectorProperties[injectorThatInjects] ?? []
+              ) == nil {
                 //Append properties need by curren injector if not present in this injector, but found in parent or in the root
                 injectorProperties[injectorThatInjects] = (injectorProperties[injectorThatInjects] ?? []) + [matched.notSelf()]
               }
@@ -190,7 +223,11 @@ func outputInjectFunction(injectorType :String, parentType: String, injectorProp
   log("------------------------------------------------------\n")
   log("\(parentType) -> \(injectorType) mappings:\n")
   targetProperties.forEach({targetProperty in 
-    if let sourceProperty = resolvePropertyFromSource(property: targetProperty,  sourceProperties: sourceProperties) { 
+    if let sourceProperty = resolvePropertyFromSource(
+        property: targetProperty,
+        allProperties: targetProperties,
+        sourceProperties: sourceProperties
+    ) {
       log("\(targetProperty.name) -> \(parentType):\(sourceProperty.name)\n")
       injectorMappings[targetProperty.name] = sourceProperty.name
     } else {
@@ -300,3 +337,4 @@ extension <%= type.name %> {
 protocol Injects<%= injector %> {}
 
 <%_ } -%>
+

--- a/Templates/Inject.swifttemplate
+++ b/Templates/Inject.swifttemplate
@@ -67,10 +67,6 @@ func resolvePropertyFromSource(property: Property, sourceProperties: [Property])
   }
 
   let sourcePropertiesOfSameType = sourceProperties.filter({$0.type == property.type})
-  if sourcePropertiesOfSameType.count == 1 {
-    return sourcePropertiesOfSameType[0]
-  }
-
   let sourcePropertiesWithSameName = sourcePropertiesOfSameType.filter({$0.name == property.name})
   return sourcePropertiesWithSameName.first
 }
@@ -116,7 +112,12 @@ func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToI
     injectablesToInjects.keys.forEach({injectable in 
         guard let injector = injectablesToInjectors[injectable] else { fatalError("\(injectable) is not Injectable") }
         guard let injects = injectablesToInjects[injectable] else { fatalError("Inject not found for \(injectable)") }
-        let injectedInjectors: [String] = injects.map({guard let injector = injectsToInjectors[$0] else { fatalError("Injector for \($0) not found") };  return injector})
+        let injectedInjectors: [String] = injects.map({
+            guard let injector = injectsToInjectors[$0] else {
+                fatalError("Injector for \($0) not found")
+            }
+            return injector
+        })
         injectorsToInjectedInjectors[injector] = (injectorsToInjectedInjectors[injector] ?? []) + injectedInjectors
         for injected in injectedInjectors {
           injectorsToInjectorsThatInject[injected] = (injectorsToInjectorsThatInject[injected] ?? []) + [injector]
@@ -157,7 +158,6 @@ func resolveDependencyTree(injectorProperties: [String: [Property]],  injectsToI
             if let matched = resolvePropertyFromInjectingRecursively(property: property, injector: injectorThatInjects, sourceProperties: injectorProperties, injectorsToInjectorsThatInject: injectorsToInjectorsThatInject, rootProperties: rootInjectorProperties) {
               if resolvePropertyFromSource(property: matched, sourceProperties: injectorProperties[injectorThatInjects] ?? []) == nil {
                 //Append properties need by curren injector if not present in this injector, but found in parent or in the root
-                // injectorProperties[injectorThatInjects]?.append(matched.notSelf())
                 injectorProperties[injectorThatInjects] = (injectorProperties[injectorThatInjects] ?? []) + [matched.notSelf()]
               }
               log("\n")
@@ -202,7 +202,7 @@ func outputInjectFunction(injectorType :String, parentType: String, injectorProp
   %>
   func inject(<%= arguments.map({"\($0.name): \($0.type)"}).joined(separator: ", ") %>) -> <%= injectorType %>Impl {
     return <%= injectorType %>Impl(
-      <%= targetProperties.map({target in let mapping = injectorMappings[target.name].map({source in useInjectorString ? "injector.\(source)" : source}) ; return "\(target.name): \(mapping ?? target.name)"}).joined(separator: ",\n      ") %>
+      <%= targetProperties.map({target in let mapping = injectorMappings[target.name].map({source in useInjectorString ? "injector.\(source)" : source}); return "\(target.name): \(mapping ?? target.name)"}).joined(separator: ",\n      ") %>
     )
   }
   <%
@@ -221,14 +221,16 @@ func outputInjectFunction(injectorType :String, parentType: String, injectorProp
   var injectorProperties: [String: [Property]] = [:]
 
   //Find root injector properties
-  guard let rootInjector =   types.all.first(where: {$0.inheritedTypes.contains("RootInjector")})  else { fatalError("RootInjector not found.") } 
+  guard let rootInjector = types.all.first(where: {$0.inheritedTypes.contains("RootInjector")})  else { fatalError("RootInjector not found.") }
   var rootInjectorProperties = rootInjector.storedVariables.map({Property(name: $0.name, type: "\($0.typeName)", forceManual: $0.annotations["forceManual"] != nil, isSelfProperty: false)}) ?? []
 
   //Find injector self properties
-  injectors.forEach {injector in 
-    injectsToInjectors["Injects\(injector.name)"] = injector.name; 
+  injectors.forEach { injector in
+    injectsToInjectors["Injects\(injector.name)"] = injector.name
+    injector.instanceVariables.forEach { variable in
+        log("\(variable.name): \(variable.typeName)\n")
+    }
     injectorProperties[injector.name] = injector.instanceVariables.map({ return Property(name: $0.name, type: "\($0.typeName)", forceManual: $0.annotations["forceManual"] != nil, isSelfProperty: true)})
-    return ;
   }
   
   // Build injection relation by 
@@ -244,6 +246,7 @@ func outputInjectFunction(injectorType :String, parentType: String, injectorProp
   //Find properties required by all injectors (including ones required by their children and found in root injector)
   injectorProperties["RootInjector"] = rootInjectorProperties
   injectorProperties = resolveDependencyTree(injectorProperties: injectorProperties, injectsToInjectors: injectsToInjectors, injectablesToInjectors: injectablesToInjectors, injectablesToInjects: injectablesToInjects)
+  
 -%>
 //Extension of RootInject which contains definition of `inject` functions creating all other Injectors.
 extension <%=  rootInjector.name %> {
@@ -297,4 +300,3 @@ extension <%= type.name %> {
 protocol Injects<%= injector %> {}
 
 <%_ } -%>
-


### PR DESCRIPTION
Given the following example:

```
protocol MessagesViewModelInjector: Injector {
    var factory: Factory { get }
    var networkManager: NetworkManager {get}
    var messagesRepository: MessagesRepository {get}
    var authenticationManager: AuthenticationManager {get}
    var wereMessagesLoadedOnLaunch: Bool { get }
    var startWithProgressAnimation: Bool { get }
    var startFromLoadingScreen: Bool { get }
}

protocol ProfilesViewModelInjector: Injector {
    var factory: Factory { get }
    var authenticationManager: AuthenticationManager {get}
}

protocol HistoryViewModelInjector: Injector {
    var factory: Factory { get }
    var messagesRepository: MessagesRepository { get }
    var wereMessagesLoadedOnLaunch: Bool { get }
    var startWithProgressAnimation: Bool { get }
    var startFromLoadingScreen: Bool { get }
}
```
with dependency flow as follows:
```
MessagesViewModelInjector -> ProfilesViewModelInjector -> HistoryViewModelInjector
```
the resolved injector that injects properties into `HistoryViewModelInjector` will result in same type properties matched by only a single same type parent property. Since `ProfilesViewModelInjector` doesn't have any of the required Bool properties it will be assigned with one after the first run of recursive properties matching and since now it owns one of the same time properties this property will be used to match all other same type properties.

With this fix we first filter same type properties so the types match and then we filter them by name. If the same type property with the exact same name couldn’t be found in any of the parent injector nor root we throw a fatalError
