### PR TITLE
Task/0.2.6 - bug fixes

### DIFF
--- a/InjectGrail.podspec
+++ b/InjectGrail.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'InjectGrail'
-  s.version          = '0.2.5'
+  s.version          = '0.2.6'
   s.summary          = 'Holy Grail of  Swift Injection frameworks for iOS and MacOs.'
   s.description      = <<-DESC
 Tired of injection framework that puts everything in one big bag of dependecy resolvers? This framework might be good for you.
@@ -25,5 +25,5 @@ Tired of injection framework that puts everything in one big bag of dependecy re
 
   s.source_files = 'InjectGrail/Classes/**/*.{swift}'
   s.preserve_paths          = 'Scripts', 'Templates'
-  s.dependency 'Sourcery', '~> 2.0.2'
+  s.dependency 'Sourcery', '~> 2.1.2'
 end

--- a/Scripts/inject.sh
+++ b/Scripts/inject.sh
@@ -25,6 +25,10 @@ fi
 
 ARGS=""
 
+if [ -n "$NO_MOCKS" ]; then
+  ARGS="noMocks,$ARGS"
+fi
+
 if [ -n "$LEGACY_INJECTION" ]; then
   ARGS="legacyInjection,$ARGS"
 fi

--- a/Templates/Inject.swifttemplate
+++ b/Templates/Inject.swifttemplate
@@ -64,7 +64,7 @@ func outputInjectFunction(injectorType :String,
     <%
   } else {
 %>
-    func inject(<%= arguments.map({"\($0.name): \($0.type)"}).joined(separator: ", ") %>) -> <%= injectorType %> {
+    func inject(<%= arguments.map({"\($0.name): \($0.type)"}).joined(separator: ", ") %>) -> <%= injectorType %>Impl {
       return <%= injectorType %>Impl(
         <%= targetProperties.map({target in let mapping = injectorMappings[target.name].map({source in useInjectorString ? "injector.\(source)" : source}); return "\(target.name): \(mapping ?? target.name)"}).joined(separator: ",\n      ") %>
       )
@@ -148,8 +148,12 @@ extension <%=  injectData.rootInjector.name %> {
 // sourcery:end
 <% } %>
 // sourcery:file:InjectGrail/Injectors.swift
+import Foundation
+<%_ for `import` in imports { -%>
+import <%= `import` %>
+<%_ } -%>
 
-<%_ 
+<%_
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Print injectors
 


### PR DESCRIPTION
- Fixed missing 'Impl' at the end of Inject method for legacyInjection
- Fixed ignoring 'NO_MOCKS' parameter
- Added missing Import to Injectors.swift (same as on 0.2.4-import-hotfix)
- Bumped Sourcery dependency to newest 2.1.2
- Lib version to 0.2.6

This compiles same as 0.2.4 - with legacyInjection.