### PR TITLE
Improve sourcery call

### DIFF
--- a/Scripts/inject.sh
+++ b/Scripts/inject.sh
@@ -44,5 +44,5 @@ fi
 echo "Extra: $EXTRA"
 echo "Args: $ARGS"
 
-"$SOURCERY_BINPATH" --templates "$TEMPLATES" --sources "$INJECT_INPUT" --output "$INJECT_OUTPUT" --args "$ARGS" "$EXTRA" "$@"
+$SOURCERY_BINPATH --templates "$TEMPLATES" --sources "$INJECT_INPUT" --output "$INJECT_OUTPUT" --args "$ARGS" "$EXTRA" "$@"
 # ./Pods/Sourcery/bin/sourcery --templates ./Templates 


### PR DESCRIPTION
With current implementation it is not possible to set $SOURCERY_BINPATH as "mint run sourcery" - as it treats it as a whole command end error out with "command not found".

Without quote marks it works.